### PR TITLE
Fix for installing required python package if missing

### DIFF
--- a/aurora.py
+++ b/aurora.py
@@ -1,4 +1,3 @@
-from nanoleaf import Aurora
 import logging
 import voluptuous as vol
 
@@ -25,6 +24,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
+    from nanoleaf import Aurora
     host = config.get(CONF_HOST)
     apikey = config.get(CONF_API_KEY)
     name = config.get(CONF_NAME)


### PR DESCRIPTION
Imports must be done inside a method for HA to be able to install.