### PR TITLE
Set triangle icon to be shown in the hass UI

### DIFF
--- a/aurora.py
+++ b/aurora.py
@@ -75,6 +75,11 @@ class AuroraLight(Light):
         return self._name
 
     @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        return "mdi:vector-triangle"
+
+    @property
     def brightness(self):
         """Return the brightness of the light."""
         return self._brightness


### PR DESCRIPTION
Set the device icon to vector-triangle, which kinda looks like an aurora panel:
<img width="441" alt="image" src="https://user-images.githubusercontent.com/431228/33635432-da54c3ee-da0f-11e7-9161-49bf7626839d.png">