### PR TITLE
Add 'support_rgb_color' to supported features

### DIFF
--- a/aurora.py
+++ b/aurora.py
@@ -12,7 +12,7 @@ import homeassistant.helpers.config_validation as cv
 
 REQUIREMENTS = ['nanoleaf==0.4.0']
 
-SUPPORT_AURORA = ( SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP )
+SUPPORT_AURORA = ( SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP | SUPPORT_RGB_COLOR )
 
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
Add SUPPORT_RGB_COLOR to the supported features array so colour can be set in the hass UI.
(Without this, the colour picker is not shown in the hass UI)